### PR TITLE
Display texture for standalone build

### DIFF
--- a/Assets/Scripts/Managers/TerrainGenerationManager.cs
+++ b/Assets/Scripts/Managers/TerrainGenerationManager.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using UnityEditor;
 using UnityEngine;
 using TerrainGeneration.Algorithms;
 using Utils;
@@ -27,8 +26,6 @@ namespace TerrainGeneration
         private Size selectedSize = Size._256;
         private ColorScheme selectedColorScheme = ColorScheme.Grayscale;
 
-        private string texturePath;
-
         public string SelectedAlgorithmTypeAsName 
         { 
             get => selectedAlgorithmType.ToString(); 
@@ -55,8 +52,6 @@ namespace TerrainGeneration
 
         void Start()
         {
-            texturePath = AssetDatabase.GetAssetPath(texture);
-
             ResetTerrain();
         }
 
@@ -98,9 +93,7 @@ namespace TerrainGeneration
         private void ApplyTexture()
         {
             // Reimport texture with corresponding max size.
-            TextureImporter importer = AssetImporter.GetAtPath(texturePath) as TextureImporter;
-            importer.maxTextureSize = SelectedSizeAsNumber;
-            AssetDatabase.ImportAsset(texturePath, ImportAssetOptions.ForceUpdate);
+            texture.Reinitialize(SelectedSizeAsNumber, SelectedSizeAsNumber);
 
             for (int x = 0; x < SelectedSizeAsNumber; x++)
             {
@@ -174,7 +167,7 @@ namespace TerrainGeneration
         private void ResetTerrain()
         {
             terrain.terrainData.heightmapResolution = SelectedSizeAsNumber;
-            AssetDatabase.ImportAsset(texturePath, ImportAssetOptions.ForceUpdate);
+            texture.Reinitialize(SelectedSizeAsNumber, SelectedSizeAsNumber);
             TerrainSizeChanged?.Invoke(SelectedSizeAsNumber);
         }
         #endregion

--- a/Assets/Scripts/Managers/UIManager.cs
+++ b/Assets/Scripts/Managers/UIManager.cs
@@ -18,6 +18,8 @@ namespace Managers
 
         void OnEnable()
         {
+            TerrainGenerationManager.TerrainSizeChanged += UpdateValueOFSizeDropdown;
+
             root = document.rootVisualElement;
             root.Q<Button>("Generate").clicked += () => terrainManager.DisplayResult();
             root.Q<Button>("Success").clicked += () =>
@@ -45,6 +47,17 @@ namespace Managers
             var gradientDropdown = root.Q<EnumField>("GradientEnum");
             gradientDropdown.RegisterValueChangedCallback(_ => terrainManager.SelectedColorSchemeAsNumber = Convert.ToInt32(_.newValue));
             gradientDropdown.value = (Enum)Enum.ToObject(gradientDropdown.value.GetType(), terrainManager.SelectedColorSchemeAsNumber);
+        }
+
+        void OnDisable()
+        {
+            TerrainGenerationManager.TerrainSizeChanged -= UpdateValueOFSizeDropdown;
+        }
+
+        private void UpdateValueOFSizeDropdown(int value)
+        {
+            var sizeDropdown = root.Q<EnumField>("SizeEnum");
+            sizeDropdown.value = (Enum)Enum.ToObject(sizeDropdown.value.GetType(), value);
         }
     }
 }


### PR DESCRIPTION
Removed all dependencies on UnityEditor APIs related to asset management (`AssetDatabase`, `AssetImporter`, etc.).

_Additionally:_
Fixed UI issue with size dropdown value not updating on texture load.